### PR TITLE
wrapper for terragrunt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+.idea

--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,7 @@ resource "yandex_alb_load_balancer" "main" {
           dynamic "external_ipv4_address" {
             for_each = l.value["address"] == "ipv4pub" ? [1] : []
             content {
-              address = var.external_ipv4_address != null ? var.external_ipv4_address : yandex_vpc_address.pip[0].external_ipv4_address[0].address
+              address = var.external_ipv4_address != "" ? var.external_ipv4_address : yandex_vpc_address.pip[0].external_ipv4_address[0].address
             }
           }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,5 +10,5 @@ output "name" {
 
 output "load_balancer_ip" {
   description = "IP address of the created load balancer"
-  value       = var.external_ipv4_address != null ? var.external_ipv4_address : yandex_vpc_address.pip[0].external_ipv4_address[0].address
+  value       = var.external_ipv4_address != "" ? var.external_ipv4_address : yandex_vpc_address.pip[0].external_ipv4_address[0].address
 }

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -1,0 +1,21 @@
+module "wrapper" {
+  source = "../"
+
+  for_each = var.items
+
+  create_pip                  = try(each.value.create_pip, var.defaults.create_pip, true)
+  description                 = try(each.value.description, var.defaults.description, null)
+  discard_rules               = try(each.value.discard_rules, var.defaults.discard_rules, null)
+  enable_logs                 = try(each.value.enable_logs, var.defaults.enable_logs, true)
+  external_ipv4_address       = try(each.value.external_ipv4_address, var.defaults.external_ipv4_address, null)
+  folder_id                   = try(each.value.folder_id, var.defaults.folder_id, null)
+  labels                      = try(each.value.labels, var.defaults.labels, {})
+  listeners                   = try(each.value.listeners, var.defaults.listeners, {})
+  log_group_id                = try(each.value.log_group_id, var.defaults.log_group_id, "")
+  name                        = try(each.value.name, var.defaults.name, null)
+  network_id                  = try(each.value.network_id, var.defaults.network_id, null)
+  pip_zone_id                 = try(each.value.pip_zone_id, var.defaults.pip_zone_id, "ru-central1-a")
+  region_id                   = try(each.value.region_id, var.defaults.region_id, null)
+  security_group_ids          = try(each.value.security_group_ids, var.defaults.security_group_ids, [])
+  subnets                     = try(each.value.subnets, var.defaults.subnets, {})
+}

--- a/wrappers/outputs.tf
+++ b/wrappers/outputs.tf
@@ -1,0 +1,5 @@
+output "wrapper" {
+  description = "Map of outputs of a wrapper."
+  value       = module.wrapper
+  sensitive   = false
+}

--- a/wrappers/variables.tf
+++ b/wrappers/variables.tf
@@ -1,0 +1,11 @@
+variable "defaults" {
+  description = "Map of default values which will be used for each item."
+  type        = any
+  default     = {}
+}
+
+variable "items" {
+  description = "Maps of items to create a wrapper from. Values are passed through to the module."
+  type        = any
+  default     = {}
+}

--- a/wrappers/versions.tf
+++ b/wrappers/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    yandex = {
+      source  = "yandex-cloud/yandex"
+      version = ">= 0.72.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 3.1.0"
+    }
+  }
+  required_version = ">= 1.3"
+}


### PR DESCRIPTION
This pull request introduces a new Terraform module configuration in the `wrappers` directory. The changes include defining the module, specifying required providers, and setting default values for variables.

### Module Configuration:

* [`wrappers/main.tf`](diffhunk://#diff-e25ea9feee9bc4d08eb2df67afb1a69c0e9bf07580cb1604c478fbc2f10491f2R1-R21): Added a new module `wrapper` that sources from the parent directory and uses the `for_each` expression to iterate over `var.items` with various configuration options using the `try` function to handle defaults.

### Outputs:

* [`wrappers/outputs.tf`](diffhunk://#diff-ca0b2f5b3caca7fcfae558fcb052e1961d06a3c1c740ec3916676208fc37f500R1-R5): Added an output `wrapper` to expose the module's outputs.

### Variables:

* [`wrappers/variables.tf`](diffhunk://#diff-78d272b6e8f345f5d2d8aa4e55f992f2733b66659193f43612c1aafbff01ea5dR1-R11): Defined two new variables, `defaults` and `items`, to provide default values and a map of items for the module configuration.

### Providers:

* [`wrappers/versions.tf`](diffhunk://#diff-fae3f8474201a9b0d80bddf286620bea79cf6f17812af6702228377452ddc53dR1-R13): Specified required providers (`yandex` and `tls`) and their versions, along with the required Terraform version.