### PR TITLE
сделал example-simple-http2 и example-simple-http2 более единообразными

### DIFF
--- a/example-simple-http/main.tf
+++ b/example-simple-http/main.tf
@@ -129,13 +129,13 @@ module "dns_recordset" {
   data    = [module.address.external_ipv4_address]
 }
 
-
 module "alb" {
   source = "../"
 
   name   = "example"
   labels = {}
 
+  folder_id = data.yandex_client_config.client.folder_id
   region_id = "ru-central1"
 
   network_id = module.network.vpc_id
@@ -178,6 +178,7 @@ module "alb" {
         target_group_ids = [
           module.instance_group.target_group_id
         ]
+
         health_check = {
           timeout                 = "30s"
           interval                = "60s"

--- a/example-simple-http2/main.tf
+++ b/example-simple-http2/main.tf
@@ -115,12 +115,13 @@ module "self_managed" {
 module "alb" {
   source = "../"
 
+  name   = "my-alb-http2"
+  labels = {}
+
   folder_id = data.yandex_client_config.client.folder_id
   region_id = "ru-central1"
 
-  name = "my-alb-http2"
-
-  network_id  = module.network.vpc_id
+  network_id = module.network.vpc_id
 
   subnets = [
     {


### PR DESCRIPTION
сделал example-simple-http2 и example-simple-http2 более похожими примерами чтобы проще их сравнивать 

```
cd terraform-yandex-alb/example-simple-http
terraform apply
Apply complete! Resources: 15 added, 0 changed, 0 destroyed.
```
и
```
cd terraform-yandex-alb/example-simple-http2
terraform apply
Apply complete! Resources: 14 added, 0 changed, 0 destroyed.
```